### PR TITLE
chore: achieve 100% test coverage and add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing
+
+We're not actively seeking contributors, but if you've found a gap in functionality or have an improvement you'd like to propose, we'd love to have a look.
+
+## Standards
+
+### Code Coverage
+
+**This repository maintains 100% code coverage as a strict standard.** All pull requests must:
+
+- Include tests for any new code
+- Maintain complete coverage for all modified code
+- Pass the automated coverage gate
+
+Run coverage locally before submitting:
+
+```bash
+composer test-coverage
+```
+
+### Code Style
+
+We use Laravel Pint for code formatting:
+
+```bash
+composer pint
+```
+
+### Static Analysis
+
+We use PHPStan for static analysis:
+
+```bash
+composer analyse
+```
+
+## Submitting Changes
+
+1. Fork the repository
+2. Create a feature branch
+3. Write tests first (TDD encouraged)
+4. Implement your changes
+5. Ensure 100% coverage is maintained
+6. Run all quality checks:
+   ```bash
+   composer pint
+   composer analyse
+   composer test-coverage
+   ```
+7. Submit a pull request with a clear description of the change
+
+## Questions
+
+Open an issue for discussion before starting significant work.

--- a/tests/Unit/Traits/ValidatesInputTest.php
+++ b/tests/Unit/Traits/ValidatesInputTest.php
@@ -33,6 +33,11 @@ class ValidatesInputTestClass
     {
         return $this->validateIssueData($data);
     }
+
+    public function testValidateMilestoneData(array $data): array
+    {
+        return $this->validateMilestoneData($data);
+    }
 }
 
 // Use a helper function to get a fresh validator instance
@@ -262,5 +267,39 @@ describe('ValidatesInput validateIssueData', function () {
         $result = inputValidator()->testValidateIssueData([]);
 
         expect($result)->toBe([]);
+    });
+});
+
+describe('ValidatesInput validateMilestoneData', function () {
+    it('validates milestone with valid data', function () {
+        $result = inputValidator()->testValidateMilestoneData([
+            'title' => 'v1.0',
+            'state' => 'open',
+            'due_on' => '2025-12-31',
+        ]);
+
+        expect($result)->toBe([
+            'title' => 'v1.0',
+            'state' => 'open',
+            'due_on' => '2025-12-31',
+        ]);
+    });
+
+    it('rejects non-string state in milestone', function () {
+        inputValidator()->testValidateMilestoneData(['state' => 123]);
+    })->throws(InvalidArgumentException::class, 'State must be a string');
+
+    it('rejects non-string due_on in milestone', function () {
+        inputValidator()->testValidateMilestoneData(['due_on' => 12345]);
+    })->throws(InvalidArgumentException::class, 'Due date must be a string or null');
+
+    it('rejects empty due_on in milestone', function () {
+        inputValidator()->testValidateMilestoneData(['due_on' => '   ']);
+    })->throws(InvalidArgumentException::class, 'Due date cannot be empty');
+
+    it('accepts null due_on to clear milestone due date', function () {
+        $result = inputValidator()->testValidateMilestoneData(['due_on' => null]);
+
+        expect($result)->toBe(['due_on' => null]);
     });
 });


### PR DESCRIPTION
## Summary

- Adds 5 milestone validation tests to cover the remaining 3 uncovered lines in `ValidatesInput.php`
- Creates `CONTRIBUTING.md` establishing 100% code coverage as the repository standard

## Changes

### Tests Added
- Milestone validation with valid data
- Rejects non-string state in milestone (line 249)
- Rejects non-string due_on in milestone (line 266)
- Rejects empty due_on in milestone (line 272)
- Accepts null due_on to clear milestone due date

### CONTRIBUTING.md
Documents that:
- We're not actively seeking contributors, but welcome gap-filling contributions
- 100% code coverage is required for all PRs
- Provides instructions for running quality checks

## Test plan

- [x] All 318 tests pass
- [x] Coverage is now 100.0%
- [x] Pint formatting passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidelines outlining code coverage standards, testing requirements, and coding style expectations.

* **Tests**
  * Extended test coverage for milestone data validation including edge cases and type checking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->