### PR TITLE
chore: use Gate @v1 for stable versioning

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -15,7 +15,7 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@v4
-      - uses: synapse-sentinel/gate@master
+      - uses: synapse-sentinel/gate@v1
         with:
           check: certify
           coverage-threshold: 100


### PR DESCRIPTION
Switch from @master to @v1 tag for stable Gate versioning.

This allows locking to semantic versions while still getting patch updates.