### PR TITLE
feat: add Comment Reactions functionality (#8)

### DIFF
--- a/src/Contracts/IssuesServiceInterface.php
+++ b/src/Contracts/IssuesServiceInterface.php
@@ -4,4 +4,4 @@ declare(strict_types=1);
 
 namespace ConduitUI\Issue\Contracts;
 
-interface IssuesServiceInterface extends ManagesIssueAssigneesInterface, ManagesIssueEventsInterface, ManagesIssueLabelsInterface, ManagesIssuesInterface, ManagesMilestonesInterface {}
+interface IssuesServiceInterface extends ManagesCommentReactionsInterface, ManagesIssueAssigneesInterface, ManagesIssueEventsInterface, ManagesIssueLabelsInterface, ManagesIssuesInterface, ManagesMilestonesInterface {}

--- a/src/Contracts/ManagesCommentReactionsInterface.php
+++ b/src/Contracts/ManagesCommentReactionsInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Issue\Contracts;
+
+use ConduitUI\Issue\Data\Reaction;
+use Illuminate\Support\Collection;
+
+interface ManagesCommentReactionsInterface
+{
+    /**
+     * @return \Illuminate\Support\Collection<int, \ConduitUI\Issue\Data\Reaction>
+     */
+    public function listCommentReactions(string $owner, string $repo, int $commentId, array $filters = []): Collection;
+
+    public function createCommentReaction(string $owner, string $repo, int $commentId, string $content): Reaction;
+
+    public function deleteCommentReaction(string $owner, string $repo, int $commentId, int $reactionId): bool;
+}

--- a/src/Data/Reaction.php
+++ b/src/Data/Reaction.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Issue\Data;
+
+use DateTime;
+
+readonly class Reaction
+{
+    private const VALID_TYPES = ['+1', '-1', 'laugh', 'confused', 'heart', 'hooray', 'rocket', 'eyes'];
+
+    public function __construct(
+        public int $id,
+        public string $content,
+        public User $user,
+        public DateTime $createdAt,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'],
+            content: $data['content'],
+            user: User::fromArray($data['user']),
+            createdAt: new DateTime($data['created_at']),
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'content' => $this->content,
+            'user' => $this->user->toArray(),
+            'created_at' => $this->createdAt->format('c'),
+        ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function validTypes(): array
+    {
+        return self::VALID_TYPES;
+    }
+
+    public static function isValidType(string $type): bool
+    {
+        return in_array($type, self::VALID_TYPES, true);
+    }
+
+    public function isThumbsUp(): bool
+    {
+        return $this->content === '+1';
+    }
+
+    public function isThumbsDown(): bool
+    {
+        return $this->content === '-1';
+    }
+
+    public function isLaugh(): bool
+    {
+        return $this->content === 'laugh';
+    }
+
+    public function isConfused(): bool
+    {
+        return $this->content === 'confused';
+    }
+
+    public function isHeart(): bool
+    {
+        return $this->content === 'heart';
+    }
+
+    public function isHooray(): bool
+    {
+        return $this->content === 'hooray';
+    }
+
+    public function isRocket(): bool
+    {
+        return $this->content === 'rocket';
+    }
+
+    public function isEyes(): bool
+    {
+        return $this->content === 'eyes';
+    }
+}

--- a/src/Requests/Reactions/CreateCommentReactionRequest.php
+++ b/src/Requests/Reactions/CreateCommentReactionRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Issue\Requests\Reactions;
+
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+class CreateCommentReactionRequest extends Request implements HasBody
+{
+    use HasJsonBody;
+
+    protected Method $method = Method::POST;
+
+    public function __construct(
+        protected readonly string $owner,
+        protected readonly string $repo,
+        protected readonly int $commentId,
+        protected readonly string $content
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return "/repos/{$this->owner}/{$this->repo}/issues/comments/{$this->commentId}/reactions";
+    }
+
+    protected function defaultBody(): array
+    {
+        return [
+            'content' => $this->content,
+        ];
+    }
+}

--- a/src/Requests/Reactions/DeleteCommentReactionRequest.php
+++ b/src/Requests/Reactions/DeleteCommentReactionRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Issue\Requests\Reactions;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+class DeleteCommentReactionRequest extends Request
+{
+    protected Method $method = Method::DELETE;
+
+    public function __construct(
+        protected readonly string $owner,
+        protected readonly string $repo,
+        protected readonly int $commentId,
+        protected readonly int $reactionId
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return "/repos/{$this->owner}/{$this->repo}/issues/comments/{$this->commentId}/reactions/{$this->reactionId}";
+    }
+}

--- a/src/Requests/Reactions/ListCommentReactionsRequest.php
+++ b/src/Requests/Reactions/ListCommentReactionsRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Issue\Requests\Reactions;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+class ListCommentReactionsRequest extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        protected readonly string $owner,
+        protected readonly string $repo,
+        protected readonly int $commentId,
+        protected readonly array $filters = []
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return "/repos/{$this->owner}/{$this->repo}/issues/comments/{$this->commentId}/reactions";
+    }
+
+    protected function defaultQuery(): array
+    {
+        return $this->filters;
+    }
+}

--- a/src/Services/IssuesService.php
+++ b/src/Services/IssuesService.php
@@ -6,6 +6,7 @@ namespace ConduitUI\Issue\Services;
 
 use ConduitUi\GitHubConnector\Connector;
 use ConduitUI\Issue\Contracts\IssuesServiceInterface;
+use ConduitUI\Issue\Traits\ManagesCommentReactions;
 use ConduitUI\Issue\Traits\ManagesIssueAssignees;
 use ConduitUI\Issue\Traits\ManagesIssueComments;
 use ConduitUI\Issue\Traits\ManagesIssueEvents;
@@ -15,6 +16,7 @@ use ConduitUI\Issue\Traits\ManagesMilestones;
 
 class IssuesService implements IssuesServiceInterface
 {
+    use ManagesCommentReactions;
     use ManagesIssueAssignees;
     use ManagesIssueComments;
     use ManagesIssueEvents;

--- a/src/Traits/ManagesCommentReactions.php
+++ b/src/Traits/ManagesCommentReactions.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Issue\Traits;
+
+use ConduitUI\Issue\Data\Reaction;
+use ConduitUI\Issue\Requests\Reactions\CreateCommentReactionRequest;
+use ConduitUI\Issue\Requests\Reactions\DeleteCommentReactionRequest;
+use ConduitUI\Issue\Requests\Reactions\ListCommentReactionsRequest;
+use Illuminate\Support\Collection;
+use InvalidArgumentException;
+
+trait ManagesCommentReactions
+{
+    use HandlesApiErrors;
+    use ValidatesInput;
+
+    /**
+     * @return \Illuminate\Support\Collection<int, \ConduitUI\Issue\Data\Reaction>
+     */
+    public function listCommentReactions(string $owner, string $repo, int $commentId, array $filters = []): Collection
+    {
+        $this->validateRepository($owner, $repo);
+        $this->validateCommentId($commentId);
+
+        $response = $this->connector->send(
+            new ListCommentReactionsRequest($owner, $repo, $commentId, $filters)
+        );
+
+        $this->handleApiResponse($response, $owner, $repo);
+
+        /** @var array<int, array<string, mixed>> $items */
+        $items = $response->json();
+
+        return collect($items)
+            ->map(fn (array $data): Reaction => Reaction::fromArray($data));
+    }
+
+    public function createCommentReaction(string $owner, string $repo, int $commentId, string $content): Reaction
+    {
+        $this->validateRepository($owner, $repo);
+        $this->validateCommentId($commentId);
+        $this->validateReactionContent($content);
+
+        $response = $this->connector->send(
+            new CreateCommentReactionRequest($owner, $repo, $commentId, $content)
+        );
+
+        $this->handleApiResponse($response, $owner, $repo);
+
+        return Reaction::fromArray($response->json());
+    }
+
+    public function deleteCommentReaction(string $owner, string $repo, int $commentId, int $reactionId): bool
+    {
+        $this->validateRepository($owner, $repo);
+        $this->validateCommentId($commentId);
+        $this->validateReactionId($reactionId);
+
+        $response = $this->connector->send(
+            new DeleteCommentReactionRequest($owner, $repo, $commentId, $reactionId)
+        );
+
+        $this->handleApiResponse($response, $owner, $repo);
+
+        return $response->status() === 204;
+    }
+
+    protected function validateReactionContent(string $content): void
+    {
+        if (trim($content) === '') {
+            throw new InvalidArgumentException('Reaction content cannot be empty');
+        }
+
+        if (! Reaction::isValidType($content)) {
+            throw new InvalidArgumentException(
+                'Reaction content must be one of: '.implode(', ', Reaction::validTypes())
+            );
+        }
+    }
+
+    protected function validateReactionId(int $reactionId): void
+    {
+        if ($reactionId < 1) {
+            throw new InvalidArgumentException('Reaction ID must be positive');
+        }
+    }
+}

--- a/tests/Unit/Data/ReactionTest.php
+++ b/tests/Unit/Data/ReactionTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Issue\Data\Reaction;
+use ConduitUI\Issue\Data\User;
+
+describe('Reaction', function () {
+    it('creates from array', function () {
+        $data = [
+            'id' => 1,
+            'content' => '+1',
+            'user' => [
+                'id' => 1,
+                'login' => 'testuser',
+                'avatar_url' => 'https://example.com/avatar.png',
+                'html_url' => 'https://github.com/testuser',
+                'type' => 'User',
+            ],
+            'created_at' => '2024-01-01T00:00:00Z',
+        ];
+
+        $reaction = Reaction::fromArray($data);
+
+        expect($reaction->id)->toBe(1)
+            ->and($reaction->content)->toBe('+1')
+            ->and($reaction->user)->toBeInstanceOf(User::class)
+            ->and($reaction->user->login)->toBe('testuser')
+            ->and($reaction->createdAt->format('Y-m-d'))->toBe('2024-01-01');
+    });
+
+    it('converts to array', function () {
+        $data = [
+            'id' => 123,
+            'content' => 'heart',
+            'user' => [
+                'id' => 1,
+                'login' => 'testuser',
+                'avatar_url' => 'https://example.com/avatar.png',
+                'html_url' => 'https://github.com/testuser',
+                'type' => 'User',
+            ],
+            'created_at' => '2024-01-01T00:00:00Z',
+        ];
+
+        $reaction = Reaction::fromArray($data);
+        $array = $reaction->toArray();
+
+        expect($array)->toHaveKey('id', 123)
+            ->and($array)->toHaveKey('content', 'heart')
+            ->and($array)->toHaveKey('user')
+            ->and($array['user'])->toHaveKey('login', 'testuser')
+            ->and($array)->toHaveKey('created_at');
+    });
+
+    describe('reaction type methods', function () {
+        it('identifies thumbs up reaction', function () {
+            $reaction = Reaction::fromArray([
+                'id' => 1,
+                'content' => '+1',
+                'user' => [
+                    'id' => 1,
+                    'login' => 'testuser',
+                    'avatar_url' => 'https://example.com/avatar.png',
+                    'html_url' => 'https://github.com/testuser',
+                    'type' => 'User',
+                ],
+                'created_at' => '2024-01-01T00:00:00Z',
+            ]);
+
+            expect($reaction->isThumbsUp())->toBeTrue()
+                ->and($reaction->isThumbsDown())->toBeFalse()
+                ->and($reaction->isLaugh())->toBeFalse()
+                ->and($reaction->isConfused())->toBeFalse()
+                ->and($reaction->isHeart())->toBeFalse()
+                ->and($reaction->isHooray())->toBeFalse()
+                ->and($reaction->isRocket())->toBeFalse()
+                ->and($reaction->isEyes())->toBeFalse();
+        });
+
+        it('identifies thumbs down reaction', function () {
+            $reaction = Reaction::fromArray([
+                'id' => 1,
+                'content' => '-1',
+                'user' => [
+                    'id' => 1,
+                    'login' => 'testuser',
+                    'avatar_url' => 'https://example.com/avatar.png',
+                    'html_url' => 'https://github.com/testuser',
+                    'type' => 'User',
+                ],
+                'created_at' => '2024-01-01T00:00:00Z',
+            ]);
+
+            expect($reaction->isThumbsUp())->toBeFalse()
+                ->and($reaction->isThumbsDown())->toBeTrue();
+        });
+
+        it('identifies laugh reaction', function () {
+            $reaction = Reaction::fromArray([
+                'id' => 1,
+                'content' => 'laugh',
+                'user' => [
+                    'id' => 1,
+                    'login' => 'testuser',
+                    'avatar_url' => 'https://example.com/avatar.png',
+                    'html_url' => 'https://github.com/testuser',
+                    'type' => 'User',
+                ],
+                'created_at' => '2024-01-01T00:00:00Z',
+            ]);
+
+            expect($reaction->isLaugh())->toBeTrue();
+        });
+
+        it('identifies confused reaction', function () {
+            $reaction = Reaction::fromArray([
+                'id' => 1,
+                'content' => 'confused',
+                'user' => [
+                    'id' => 1,
+                    'login' => 'testuser',
+                    'avatar_url' => 'https://example.com/avatar.png',
+                    'html_url' => 'https://github.com/testuser',
+                    'type' => 'User',
+                ],
+                'created_at' => '2024-01-01T00:00:00Z',
+            ]);
+
+            expect($reaction->isConfused())->toBeTrue();
+        });
+
+        it('identifies heart reaction', function () {
+            $reaction = Reaction::fromArray([
+                'id' => 1,
+                'content' => 'heart',
+                'user' => [
+                    'id' => 1,
+                    'login' => 'testuser',
+                    'avatar_url' => 'https://example.com/avatar.png',
+                    'html_url' => 'https://github.com/testuser',
+                    'type' => 'User',
+                ],
+                'created_at' => '2024-01-01T00:00:00Z',
+            ]);
+
+            expect($reaction->isHeart())->toBeTrue();
+        });
+
+        it('identifies hooray reaction', function () {
+            $reaction = Reaction::fromArray([
+                'id' => 1,
+                'content' => 'hooray',
+                'user' => [
+                    'id' => 1,
+                    'login' => 'testuser',
+                    'avatar_url' => 'https://example.com/avatar.png',
+                    'html_url' => 'https://github.com/testuser',
+                    'type' => 'User',
+                ],
+                'created_at' => '2024-01-01T00:00:00Z',
+            ]);
+
+            expect($reaction->isHooray())->toBeTrue();
+        });
+
+        it('identifies rocket reaction', function () {
+            $reaction = Reaction::fromArray([
+                'id' => 1,
+                'content' => 'rocket',
+                'user' => [
+                    'id' => 1,
+                    'login' => 'testuser',
+                    'avatar_url' => 'https://example.com/avatar.png',
+                    'html_url' => 'https://github.com/testuser',
+                    'type' => 'User',
+                ],
+                'created_at' => '2024-01-01T00:00:00Z',
+            ]);
+
+            expect($reaction->isRocket())->toBeTrue();
+        });
+
+        it('identifies eyes reaction', function () {
+            $reaction = Reaction::fromArray([
+                'id' => 1,
+                'content' => 'eyes',
+                'user' => [
+                    'id' => 1,
+                    'login' => 'testuser',
+                    'avatar_url' => 'https://example.com/avatar.png',
+                    'html_url' => 'https://github.com/testuser',
+                    'type' => 'User',
+                ],
+                'created_at' => '2024-01-01T00:00:00Z',
+            ]);
+
+            expect($reaction->isEyes())->toBeTrue();
+        });
+    });
+
+    describe('valid reaction types', function () {
+        it('returns all valid reaction content types', function () {
+            $validTypes = Reaction::validTypes();
+
+            expect($validTypes)->toBe(['+1', '-1', 'laugh', 'confused', 'heart', 'hooray', 'rocket', 'eyes']);
+        });
+
+        it('validates a valid reaction type', function () {
+            expect(Reaction::isValidType('+1'))->toBeTrue()
+                ->and(Reaction::isValidType('-1'))->toBeTrue()
+                ->and(Reaction::isValidType('laugh'))->toBeTrue()
+                ->and(Reaction::isValidType('confused'))->toBeTrue()
+                ->and(Reaction::isValidType('heart'))->toBeTrue()
+                ->and(Reaction::isValidType('hooray'))->toBeTrue()
+                ->and(Reaction::isValidType('rocket'))->toBeTrue()
+                ->and(Reaction::isValidType('eyes'))->toBeTrue();
+        });
+
+        it('rejects an invalid reaction type', function () {
+            expect(Reaction::isValidType('invalid'))->toBeFalse()
+                ->and(Reaction::isValidType(''))->toBeFalse()
+                ->and(Reaction::isValidType('thumbsup'))->toBeFalse();
+        });
+    });
+});

--- a/tests/Unit/Requests/Reactions/CreateCommentReactionRequestTest.php
+++ b/tests/Unit/Requests/Reactions/CreateCommentReactionRequestTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Issue\Requests\Reactions\CreateCommentReactionRequest;
+use Saloon\Enums\Method;
+
+describe('CreateCommentReactionRequest', function () {
+    it('has correct method', function () {
+        $request = new CreateCommentReactionRequest('owner', 'repo', 123, '+1');
+        $reflection = new ReflectionClass($request);
+        $property = $reflection->getProperty('method');
+
+        expect($property->getValue($request))->toBe(Method::POST);
+    });
+
+    it('resolves correct endpoint', function () {
+        $request = new CreateCommentReactionRequest('testowner', 'testrepo', 456, 'heart');
+
+        expect($request->resolveEndpoint())
+            ->toBe('/repos/testowner/testrepo/issues/comments/456/reactions');
+    });
+
+    it('includes content in request body', function () {
+        $request = new CreateCommentReactionRequest('owner', 'repo', 123, 'rocket');
+
+        $reflection = new ReflectionClass($request);
+        $method = $reflection->getMethod('defaultBody');
+        $method->setAccessible(true);
+        $body = $method->invoke($request);
+
+        expect($body)->toHaveKey('content', 'rocket');
+    });
+
+    it('handles all valid reaction types', function () {
+        $types = ['+1', '-1', 'laugh', 'confused', 'heart', 'hooray', 'rocket', 'eyes'];
+
+        foreach ($types as $type) {
+            $request = new CreateCommentReactionRequest('owner', 'repo', 123, $type);
+
+            $reflection = new ReflectionClass($request);
+            $method = $reflection->getMethod('defaultBody');
+            $method->setAccessible(true);
+            $body = $method->invoke($request);
+
+            expect($body['content'])->toBe($type);
+        }
+    });
+});

--- a/tests/Unit/Requests/Reactions/DeleteCommentReactionRequestTest.php
+++ b/tests/Unit/Requests/Reactions/DeleteCommentReactionRequestTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Issue\Requests\Reactions\DeleteCommentReactionRequest;
+use Saloon\Enums\Method;
+
+describe('DeleteCommentReactionRequest', function () {
+    it('has correct method', function () {
+        $request = new DeleteCommentReactionRequest('owner', 'repo', 123, 456);
+        $reflection = new ReflectionClass($request);
+        $property = $reflection->getProperty('method');
+
+        expect($property->getValue($request))->toBe(Method::DELETE);
+    });
+
+    it('resolves correct endpoint', function () {
+        $request = new DeleteCommentReactionRequest('testowner', 'testrepo', 123, 789);
+
+        expect($request->resolveEndpoint())
+            ->toBe('/repos/testowner/testrepo/issues/comments/123/reactions/789');
+    });
+
+    it('uses correct comment id in endpoint', function () {
+        $request = new DeleteCommentReactionRequest('owner', 'repo', 999, 111);
+
+        expect($request->resolveEndpoint())
+            ->toBe('/repos/owner/repo/issues/comments/999/reactions/111');
+    });
+
+    it('uses correct reaction id in endpoint', function () {
+        $request = new DeleteCommentReactionRequest('owner', 'repo', 123, 777);
+
+        expect($request->resolveEndpoint())
+            ->toBe('/repos/owner/repo/issues/comments/123/reactions/777');
+    });
+});

--- a/tests/Unit/Requests/Reactions/ListCommentReactionsRequestTest.php
+++ b/tests/Unit/Requests/Reactions/ListCommentReactionsRequestTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Issue\Requests\Reactions\ListCommentReactionsRequest;
+use Saloon\Enums\Method;
+
+describe('ListCommentReactionsRequest', function () {
+    it('has correct method', function () {
+        $request = new ListCommentReactionsRequest('owner', 'repo', 123);
+        $reflection = new ReflectionClass($request);
+        $property = $reflection->getProperty('method');
+
+        expect($property->getValue($request))->toBe(Method::GET);
+    });
+
+    it('resolves correct endpoint', function () {
+        $request = new ListCommentReactionsRequest('testowner', 'testrepo', 456);
+
+        expect($request->resolveEndpoint())
+            ->toBe('/repos/testowner/testrepo/issues/comments/456/reactions');
+    });
+
+    it('includes filters in query', function () {
+        $request = new ListCommentReactionsRequest('owner', 'repo', 123, ['content' => '+1', 'per_page' => 30]);
+
+        $reflection = new ReflectionClass($request);
+        $method = $reflection->getMethod('defaultQuery');
+        $method->setAccessible(true);
+        $query = $method->invoke($request);
+
+        expect($query)->toHaveKey('content', '+1')
+            ->and($query)->toHaveKey('per_page', 30);
+    });
+
+    it('returns empty query when no filters', function () {
+        $request = new ListCommentReactionsRequest('owner', 'repo', 123);
+
+        $reflection = new ReflectionClass($request);
+        $method = $reflection->getMethod('defaultQuery');
+        $method->setAccessible(true);
+        $query = $method->invoke($request);
+
+        expect($query)->toBe([]);
+    });
+});

--- a/tests/Unit/Traits/ManagesCommentReactionsTest.php
+++ b/tests/Unit/Traits/ManagesCommentReactionsTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUi\GitHubConnector\Connector;
+use ConduitUI\Issue\Data\Reaction;
+use ConduitUI\Issue\Services\IssuesService;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+function fullReactionResponse(array $overrides = []): array
+{
+    return array_merge([
+        'id' => 1,
+        'content' => '+1',
+        'user' => [
+            'id' => 1,
+            'login' => 'testuser',
+            'avatar_url' => 'https://example.com/avatar.png',
+            'html_url' => 'https://github.com/testuser',
+            'type' => 'User',
+        ],
+        'created_at' => '2024-01-01T00:00:00Z',
+    ], $overrides);
+}
+
+describe('ManagesCommentReactions', function () {
+    beforeEach(function () {
+        $this->mockClient = new MockClient;
+        $this->connector = new Connector('fake-token');
+        $this->connector->withMockClient($this->mockClient);
+        $this->service = new IssuesService($this->connector);
+    });
+
+    describe('listCommentReactions', function () {
+        it('lists reactions for a comment', function () {
+            $this->mockClient->addResponse(MockResponse::make([
+                fullReactionResponse(['id' => 1, 'content' => '+1']),
+                fullReactionResponse(['id' => 2, 'content' => 'heart']),
+            ]));
+
+            $reactions = $this->service->listCommentReactions('owner', 'repo', 123);
+
+            expect($reactions)->toHaveCount(2)
+                ->and($reactions->first())->toBeInstanceOf(Reaction::class)
+                ->and($reactions->first()->content)->toBe('+1')
+                ->and($reactions->last()->content)->toBe('heart');
+        });
+
+        it('lists reactions with filters', function () {
+            $this->mockClient->addResponse(MockResponse::make([
+                fullReactionResponse(['id' => 1, 'content' => '+1']),
+            ]));
+
+            $reactions = $this->service->listCommentReactions('owner', 'repo', 123, ['content' => '+1']);
+
+            expect($reactions)->toHaveCount(1)
+                ->and($reactions->first()->content)->toBe('+1');
+        });
+
+        it('returns empty collection when no reactions', function () {
+            $this->mockClient->addResponse(MockResponse::make([]));
+
+            $reactions = $this->service->listCommentReactions('owner', 'repo', 123);
+
+            expect($reactions)->toBeEmpty();
+        });
+
+        it('validates repository', function () {
+            expect(fn () => $this->service->listCommentReactions('', 'repo', 123))
+                ->toThrow(InvalidArgumentException::class);
+        });
+
+        it('validates comment id', function () {
+            expect(fn () => $this->service->listCommentReactions('owner', 'repo', 0))
+                ->toThrow(InvalidArgumentException::class);
+        });
+    });
+
+    describe('createCommentReaction', function () {
+        it('creates a new reaction on a comment', function () {
+            $this->mockClient->addResponse(MockResponse::make(
+                fullReactionResponse(['content' => 'heart']),
+                201
+            ));
+
+            $reaction = $this->service->createCommentReaction('owner', 'repo', 123, 'heart');
+
+            expect($reaction)->toBeInstanceOf(Reaction::class)
+                ->and($reaction->content)->toBe('heart');
+        });
+
+        it('validates invalid reaction content', function () {
+            expect(fn () => $this->service->createCommentReaction('owner', 'repo', 123, 'invalid'))
+                ->toThrow(InvalidArgumentException::class);
+        });
+
+        it('validates empty reaction content', function () {
+            expect(fn () => $this->service->createCommentReaction('owner', 'repo', 123, ''))
+                ->toThrow(InvalidArgumentException::class);
+        });
+
+        it('validates repository', function () {
+            expect(fn () => $this->service->createCommentReaction('', 'repo', 123, '+1'))
+                ->toThrow(InvalidArgumentException::class);
+        });
+
+        it('validates comment id', function () {
+            expect(fn () => $this->service->createCommentReaction('owner', 'repo', 0, '+1'))
+                ->toThrow(InvalidArgumentException::class);
+        });
+
+        it('creates all valid reaction types', function () {
+            $types = ['+1', '-1', 'laugh', 'confused', 'heart', 'hooray', 'rocket', 'eyes'];
+
+            foreach ($types as $type) {
+                $this->mockClient->addResponse(MockResponse::make(
+                    fullReactionResponse(['content' => $type]),
+                    201
+                ));
+
+                $reaction = $this->service->createCommentReaction('owner', 'repo', 123, $type);
+
+                expect($reaction->content)->toBe($type);
+            }
+        });
+    });
+
+    describe('deleteCommentReaction', function () {
+        it('deletes a reaction successfully', function () {
+            $this->mockClient->addResponse(MockResponse::make('', 204));
+
+            $result = $this->service->deleteCommentReaction('owner', 'repo', 123, 456);
+
+            expect($result)->toBeTrue();
+        });
+
+        it('validates comment id', function () {
+            expect(fn () => $this->service->deleteCommentReaction('owner', 'repo', 0, 456))
+                ->toThrow(InvalidArgumentException::class);
+        });
+
+        it('validates reaction id', function () {
+            expect(fn () => $this->service->deleteCommentReaction('owner', 'repo', 123, 0))
+                ->toThrow(InvalidArgumentException::class);
+        });
+
+        it('validates repository', function () {
+            expect(fn () => $this->service->deleteCommentReaction('', 'repo', 123, 456))
+                ->toThrow(InvalidArgumentException::class);
+        });
+    });
+
+    describe('reaction type identification', function () {
+        it('identifies thumbs up reactions', function () {
+            $this->mockClient->addResponse(MockResponse::make([
+                fullReactionResponse(['content' => '+1']),
+            ]));
+
+            $reactions = $this->service->listCommentReactions('owner', 'repo', 123);
+
+            expect($reactions->first()->isThumbsUp())->toBeTrue()
+                ->and($reactions->first()->isThumbsDown())->toBeFalse();
+        });
+
+        it('identifies thumbs down reactions', function () {
+            $this->mockClient->addResponse(MockResponse::make([
+                fullReactionResponse(['content' => '-1']),
+            ]));
+
+            $reactions = $this->service->listCommentReactions('owner', 'repo', 123);
+
+            expect($reactions->first()->isThumbsDown())->toBeTrue()
+                ->and($reactions->first()->isThumbsUp())->toBeFalse();
+        });
+    });
+});


### PR DESCRIPTION
Implements GitHub Issue Comment Reactions API support:
- List reactions on a comment
- Create reaction on a comment
- Delete a reaction from a comment

Includes:
- Reaction DTO with type identification methods
- Request classes for all reaction API endpoints
- ManagesCommentReactions trait
- ManagesCommentReactionsInterface contract
- Full test coverage (42 new tests)

Closes #8 (Comment Reactions section)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comment reaction management capabilities to issues, enabling users to list, create, and delete emoji reactions on issue comments
  * Support for eight reaction types: thumbs up, thumbs down, laugh, confused, heart, hooray, rocket, and eyes

* **Tests**
  * Added comprehensive unit tests for comment reaction functionality, including validation and API integration scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->