### PR TITLE
docs: add Comment Reactions documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,25 @@ $issue->comment('Thanks for reporting! Our team will investigate.');
 $comments = $issue->comments();
 ```
 
+**Comment Reactions**
+```php
+use ConduitUI\Issue\Facades\Issue;
+
+// Add a reaction to a comment
+$reaction = Issue::createCommentReaction('owner', 'repo', $commentId, '+1');
+
+// List all reactions on a comment
+$reactions = Issue::listCommentReactions('owner', 'repo', $commentId);
+
+// Filter reactions by type
+$thumbsUp = $reactions->filter(fn($r) => $r->isThumbsUp());
+
+// Remove a reaction
+Issue::deleteCommentReaction('owner', 'repo', $commentId, $reactionId);
+```
+
+Available reaction types: `+1`, `-1`, `laugh`, `confused`, `heart`, `hooray`, `rocket`, `eyes`
+
 **Lock & Unlock**
 ```php
 // Lock heated discussions


### PR DESCRIPTION
Add usage examples for the Comment Reactions API including:
- Creating reactions on comments
- Listing reactions with type filtering
- Deleting reactions
- List of available reaction types

Closes #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Comment Reactions section with API documentation and usage examples
  * Included examples for creating, listing, filtering by type, and deleting reactions
  * Documented available reaction types: +1, -1, laugh, confused, heart, hooray, rocket, eyes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->